### PR TITLE
Added new filter & from now pseudo-admins can't ban members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 venv
 .idea/
+censure/censure/lang/__pycache__
+censure/censure/lang/common/__pycache__
+censure/censure/lang/en/__pycache__
+censure/censure/lang/ru/__pycache__
+__pycache__

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -1,7 +1,9 @@
 import logging
+
 from aiogram import Bot, Dispatcher
+
 from configurator import config, check_config_file
-from filters import IsAdminFilter
+from filters import IsAdminFilter, MemberCanRestrictFilter
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -18,3 +20,4 @@ dp = Dispatcher(bot)
 
 # Activate filters
 dp.filters_factory.bind(IsAdminFilter)
+dp.filters_factory.bind(MemberCanRestrictFilter)

--- a/filters.py
+++ b/filters.py
@@ -1,15 +1,32 @@
 from aiogram import types
 from aiogram.dispatcher.filters import BoundFilter
 
+
 class IsAdminFilter(BoundFilter):
     """
-    Custom class to asdd "is_admin" filter for some handlers below
+    Filter that checks for admin rights existence
     """
-    key = 'is_admin'
+    key = "is_admin"
 
-    def __init__(self, is_admin):
+    def __init__(self, is_admin: bool):
         self.is_admin = is_admin
 
     async def check(self, message: types.Message):
         member = await message.bot.get_chat_member(message.chat.id, message.from_user.id)
         return member.is_chat_admin() == self.is_admin
+
+
+class MemberCanRestrictFilter(BoundFilter):
+    """
+    Filter that checks member ability for restricting
+    """
+    key = 'member_can_restrict'
+
+    def __init__(self, member_can_restrict: bool):
+        self.member_can_restrict = member_can_restrict
+
+    async def check(self, message: types.Message):
+        member = await message.bot.get_chat_member(message.chat.id, message.from_user.id)
+
+        # I don't know why, but telegram thinks, if member is chat creator, he cant restrict member
+        return member.can_restrict_members == self.member_can_restrict or member.is_chat_creator()

--- a/handlers/admin_actions.py
+++ b/handlers/admin_actions.py
@@ -199,7 +199,7 @@ async def cmd_checkperms(message: types.Message):
     await message.reply(msg)'''
 
 
-@dp.message_handler(is_admin=True, chat_id=config.groups.main, commands=["ban"], commands_prefix="!/")
+@dp.message_handler(member_can_restrict=True, chat_id=config.groups.main, commands=["ban"], commands_prefix="!/")
 async def cmd_ban(message: types.Message):
     # Check if command is sent as reply to some message
     if not message.reply_to_message:
@@ -212,12 +212,13 @@ async def cmd_ban(message: types.Message):
         await message.reply(localization.get_string("error_ban_admin"))
         return
 
-    await message.bot.delete_message(config.groups.main, message.message_id) # remove admin message
+    await message.bot.delete_message(config.groups.main, message.message_id)  # remove admin message
     await message.bot.kick_chat_member(chat_id=config.groups.main, user_id=message.reply_to_message.from_user.id)
 
     await message.reply_to_message.reply(localization.get_string("resolved_ban"))
 
-@dp.message_handler(is_admin=True, chat_id=config.groups.main, commands=["unban"], commands_prefix="!/")
+
+@dp.message_handler(member_can_restrict=True, chat_id=config.groups.main, commands=["unban"], commands_prefix="!/")
 async def cmd_unban(message: types.Message):
     # Check if command is sent as reply to some message
     if not message.reply_to_message:
@@ -230,10 +231,11 @@ async def cmd_unban(message: types.Message):
         await message.reply(localization.get_string("error_ban_admin"))
         return
 
-    await message.bot.delete_message(config.groups.main, message.message_id) # remove admin message
+    await message.bot.delete_message(config.groups.main, message.message_id)  # remove admin message
     await message.bot.unban_chat_member(chat_id=config.groups.main, user_id=message.reply_to_message.from_user.id)
 
     await message.reply_to_message.reply(localization.get_string("resolved_unban"))
+
 
 '''@dp.message_handler(is_admin=True, chat_id=config.groups.main, commands=["ro"], commands_prefix="!")
 async def cmd_ro(message: types.Message):

--- a/utils.py
+++ b/utils.py
@@ -1,17 +1,19 @@
 import datetime
+import sys
 import typing
+
 import localization
 from configurator import config
 
-import sys
-sys.path.append("./censure") # allow module import from git submodule
+sys.path.append("./censure")  # allow module import from git submodule
 
 from censure import Censor
 
 censor_ru = Censor.get(lang='ru')
 censor_en = Censor.get(lang='en')
 
-def check_for_profanity(text, lang = "ru"):
+
+def check_for_profanity(text, lang="ru"):
     _profanity_detected = False
     _word = None
 
@@ -33,19 +35,21 @@ def check_for_profanity(text, lang = "ru"):
 
     return _profanity_detected, _word, line_info
 
+
 def check_for_profanity_all(text):
     _del = False
     _word = None
     _line = None
 
-      # Check for RUSSIAN
-    _del, _word, _line = check_for_profanity(text, lang = "ru")
+    # Check for RUSSIAN
+    _del, _word, _line = check_for_profanity(text, lang="ru")
 
     if not _del:
         # Check for ENGLISH
-        _del, _word, _line = check_for_profanity(text, lang = "en")
+        _del, _word, _line = check_for_profanity(text, lang="en")
 
     return _del, _word
+
 
 def user_mention(from_user):
     _s = from_user.full_name
@@ -53,11 +57,12 @@ def user_mention(from_user):
     if from_user.full_name != from_user.mention:
         _s += " (" + from_user.mention + ")"
     else:
-        _s += " (<a href=\""+from_user.url+"\">id"+str(from_user.id)+"</a>)"
+        _s += " (<a href=\"" + from_user.url + "\">id" + str(from_user.id) + "</a>)"
 
     return _s
 
-async def write_log(bot, message, log_type = "default"):
+
+async def write_log(bot, message, log_type="default"):
     now = datetime.datetime.now()
     current_time = now.strftime("%H:%M:%S")
 
@@ -65,6 +70,7 @@ async def write_log(bot, message, log_type = "default"):
     log_message += message
 
     return await bot.send_message(config.groups.logs, log_message)
+
 
 def get_restriction_time(string: str) -> typing.Optional[int]:
     """
@@ -121,7 +127,8 @@ def get_url_chat_id(chat_id: int) -> int:
     :param chat_id: chat_id to apply magic number to
     :return: chat_id for t.me links
     """
-    return abs(chat_id+1_000_000_000_000)
+    return abs(chat_id + 1_000_000_000_000)
+
 
 def remove_prefix(text, prefix):
     if text.startswith(prefix):


### PR DESCRIPTION
Hello Abraham!

I create filter for checking restriction ability.
Because in your chat I have only prefix, but I can restrict chatmembers.
I fix it.

Here is code of new filter.

![image](https://user-images.githubusercontent.com/56587546/125464036-30ebd473-f1bc-4c76-8f4b-19cae57147a9.png)

By [WinDuz](https://t.me/winduz)